### PR TITLE
Include a detailed error for RDP negotiation failures

### DIFF
--- a/src/core/x224.rs
+++ b/src/core/x224.rs
@@ -7,6 +7,8 @@ use std::convert::TryFrom;
 use std::io::{Read, Write};
 use std::option::Option;
 
+use crate::model::error::ProtocolNegFailureCode;
+
 #[repr(u8)]
 #[derive(Copy, Clone, TryFromPrimitive)]
 pub enum NegotiationType {
@@ -269,7 +271,11 @@ impl<S: Read + Write> Client<S> {
         match NegotiationType::try_from(cast!(DataType::U8, nego["type"])?)? {
             NegotiationType::TypeRDPNegFailure => Err(Error::RdpError(RdpError::new(
                 RdpErrorKind::ProtocolNegFailure,
-                "Error during negotiation step",
+                format!(
+                    "Error during negotiation step: {}",
+                    ProtocolNegFailureCode::from_code(cast!(DataType::U32, nego["result"])?)
+                )
+                .as_str(),
             ))),
             NegotiationType::TypeRDPNegReq => Err(Error::RdpError(RdpError::new(
                 RdpErrorKind::InvalidAutomata,


### PR DESCRIPTION
Instead of emitting an identical error message for all protocol
negotiation failures, consult the failure code field of the message
and use it to generate a better error.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/1b3920e7-0116-4345-bc45-f2c4ad012761