### PR TITLE
Revert static channels type change

### DIFF
--- a/src/core/mcs.rs
+++ b/src/core/mcs.rs
@@ -226,7 +226,7 @@ impl<S: Read + Write> Client<S> {
         screen_height: u16,
         keyboard_layout: KeyboardLayout,
         client_name: String,
-        static_channels: &[&str],
+        static_channels: &[String],
     ) -> RdpResult<()> {
         let client_core_data = client_core_data(Some(ClientData {
             width: screen_width,
@@ -271,7 +271,7 @@ impl<S: Read + Write> Client<S> {
     }
 
     /// Read a connect response comming from server to client
-    fn read_connect_response(&mut self, static_channels: &[&str]) -> RdpResult<()> {
+    fn read_connect_response(&mut self, static_channels: &[String]) -> RdpResult<()> {
         // Now read response from the server
         let mut connect_response = connect_response(None);
         let mut payload = try_let!(tpkt::Payload::Raw, self.x224.read()?)?;
@@ -313,14 +313,14 @@ impl<S: Read + Write> Client<S> {
         screen_width: u16,
         screen_height: u16,
         keyboard_layout: KeyboardLayout,
-        static_channels: &[&str],
+        static_channels: &[String],
     ) -> RdpResult<()> {
         self.write_connect_initial(
             screen_width,
             screen_height,
             keyboard_layout,
             client_name,
-            static_channels,
+            &static_channels,
         )?;
         self.read_connect_response(&static_channels)?;
         self.x224.write(erect_domain_request()?)?;

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -113,6 +113,7 @@ impl fmt::Display for ProtocolNegFailureCode {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct RdpError {
     /// Kind of error
     kind: RdpErrorKind,


### PR DESCRIPTION
In https://github.com/gravitational/rdp-rs/commit/a890091a4e86ec804dfad19fdc2ccb56ae4003f8 we made the static channels a `&[&str]` because at the time, the static channels we needed were always known at compile time, so there was no need for heap allocations.

Since then, we've implemented clipboard sharing, which adds a new static channel that is optionally opened at **runtime** (based on RBAC), so we need to go back to the previous approach.