### PR TITLE
Swap native-tls library with rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ integration = []
 mstsc-rs = ["hex", "winapi", "minifb", "clap", "libc"]
 
 [dependencies]
-native-tls = "^0.2"
 byteorder = "^1.3"
 bufstream = "0.1"
 indexmap = "^1.3"
@@ -38,6 +37,7 @@ rand = "^0.7"
 num-bigint = "^0.2"
 x509-parser = "0.6.5"
 num_enum = "0.4.3"
+rustls = { version = "0.20.4", features = ["dangerous_configuration"]}
 
 # for mtsc-rs
 hex = { version = "^0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@ extern crate md4;
 extern crate md5;
 #[cfg(feature = "mstsc-rs")]
 extern crate minifb;
-extern crate native_tls;
 extern crate num_bigint;
 extern crate num_enum;
 extern crate rand;

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -1,11 +1,9 @@
-extern crate native_tls;
+extern crate rustls;
 
-use self::native_tls::Error as SslError;
-use self::native_tls::HandshakeError;
+use self::rustls::Error as SslError;
 use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use std::fmt;
 use std::io::Error as IoError;
-use std::io::{Read, Write};
 use std::string::String;
 use yasna::ASN1Error;
 
@@ -168,12 +166,6 @@ pub enum Error {
 impl From<IoError> for Error {
     fn from(e: IoError) -> Self {
         Error::Io(e)
-    }
-}
-
-impl<S: Read + Write> From<HandshakeError<S>> for Error {
-    fn from(_: HandshakeError<S>) -> Error {
-        Error::SslHandshakeError
     }
 }
 

--- a/src/model/link.rs
+++ b/src/model/link.rs
@@ -1,9 +1,114 @@
-extern crate native_tls;
+extern crate rustls;
 
-use self::native_tls::{Certificate, TlsConnector, TlsStream};
 use model::data::Message;
 use model::error::{Error, RdpError, RdpErrorKind, RdpResult};
+use std::convert::TryInto;
 use std::io::{Cursor, Read, Write};
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use self::rustls::{
+    client::{NoClientSessionStorage, ServerCertVerified, ServerCertVerifier},
+    Certificate, ClientConfig, ClientConnection, ConnectionCommon, Error as RustlsError,
+    RootCertStore, ServerName, SideData, Stream as RustlsStream,
+};
+
+/// Marks all server certificates as valid
+/// so it can be used to turn off the server certificate
+/// validation on the client-side.
+struct DummyTlsVerifier;
+
+impl ServerCertVerifier for DummyTlsVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+/// Copied from rustls library with removed trait bounds (Read + Write)
+/// By removing trait bounds we don't have to update
+/// other structs that depends on the Stream enum
+pub struct StreamOwned<C: Sized, T: Sized> {
+    /// Our conneciton
+    pub conn: C,
+
+    /// The underlying transport, like a socket
+    pub sock: T,
+}
+
+impl<C, T, S> StreamOwned<C, T>
+where
+    C: DerefMut + Deref<Target = ConnectionCommon<S>>,
+    T: Read + Write,
+    S: SideData,
+{
+    /// Make a new StreamOwned taking the Connection `conn` and socket-like
+    /// object `sock`.  This does not fail and does no IO.
+    ///
+    /// This is the same as `Stream::new` except `conn` and `sock` are
+    /// moved into the StreamOwned.
+    pub fn new(conn: C, sock: T) -> Self {
+        Self { conn, sock }
+    }
+
+    /// Get a reference to the underlying socket
+    pub fn get_ref(&self) -> &T {
+        &self.sock
+    }
+
+    /// Get a mutable reference to the underlying socket
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.sock
+    }
+
+    fn as_stream(&mut self) -> RustlsStream<C, T> {
+        RustlsStream {
+            conn: &mut self.conn,
+            sock: &mut self.sock,
+        }
+    }
+}
+
+impl<C, T, S> Read for StreamOwned<C, T>
+where
+    C: DerefMut + Deref<Target = ConnectionCommon<S>>,
+    T: Read + Write,
+    S: SideData,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.as_stream().read(buf)
+    }
+
+    #[cfg(read_buf)]
+    fn read_buf(&mut self, buf: &mut std::io::ReadBuf<'_>) -> std::io::Result<()> {
+        self.as_stream().read_buf(buf)
+    }
+}
+
+impl<C, T, S> Write for StreamOwned<C, T>
+where
+    C: DerefMut + Deref<Target = ConnectionCommon<S>>,
+    T: Read + Write,
+    S: SideData,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.as_stream().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.as_stream().flush()
+    }
+}
+
+pub type TlsStream<S> = StreamOwned<ClientConnection, S>;
 
 /// This a wrapper to work equals
 /// for a stream and a TLS stream
@@ -78,10 +183,11 @@ impl<S: Read + Write> Stream<S> {
     /// Shutdown the stream
     /// Only works when stream is a SSL stream
     pub fn shutdown(&mut self) -> RdpResult<()> {
-        Ok(match self {
-            Stream::Ssl(e) => e.shutdown()?,
-            _ => (),
-        })
+        if let Stream::Ssl(stream) = self {
+                stream.conn.send_close_notify();
+                stream.flush()?;
+        }
+        Ok(())
     }
 }
 
@@ -171,14 +277,33 @@ impl<S: Read + Write> Link<S> {
     /// let link_ssl = link_tcp.start_ssl(false).unwrap();
     /// ```
     pub fn start_ssl(self, check_certificate: bool) -> RdpResult<Link<S>> {
-        let mut builder = TlsConnector::builder();
-        builder.danger_accept_invalid_certs(!check_certificate);
-        builder.use_sni(false);
+        let root_store = RootCertStore::empty();
+        let mut config = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
 
-        let connector = builder.build()?;
+        if !check_certificate {
+            let mut config = config.dangerous();
+            let verifier = Arc::new(DummyTlsVerifier {});
+            config.set_certificate_verifier(verifier)
+        }
+
+        config.enable_sni = false;
+        // We do not use the Server Name Indication (SNI) extension
+        // during the client handshake, but the rustls library requires
+        // a valid DNS domain name for the server regardless of that
+        // setting, so we need to provide a valid name.
+        // We can't use an empty string here.
+        let server_name: ServerName = "servername".try_into().unwrap();
+        config.session_storage = Arc::new(NoClientSessionStorage {});
+
+        let arc = Arc::new(config);
+        let conn = ClientConnection::new(arc, server_name)?;
 
         if let Stream::Raw(stream) = self.stream {
-            return Ok(Link::new(Stream::Ssl(connector.connect("", stream)?)));
+            let owned = TlsStream::new(conn, stream);
+            return Ok(Link::new(Stream::Ssl(owned)));
         }
         Err(Error::RdpError(RdpError::new(
             RdpErrorKind::NotImplemented,
@@ -200,7 +325,21 @@ impl<S: Read + Write> Link<S> {
     /// ```
     pub fn get_peer_certificate(&self) -> RdpResult<Option<Certificate>> {
         if let Stream::Ssl(stream) = &self.stream {
-            Ok(stream.peer_certificate()?)
+            if let Some(certs) = stream.conn.peer_certificates() {
+                if let Some(cert) = certs.first() {
+                    Ok(Some(cert.clone()))
+                } else {
+                    Err(Error::RdpError(RdpError::new(
+                        RdpErrorKind::InvalidData,
+                        "certificates chain is empty",
+                    )))
+                }
+            } else {
+                Err(Error::RdpError(RdpError::new(
+                    RdpErrorKind::InvalidData,
+                    "certificates chain is unavialable",
+                )))
+            }
         } else {
             Err(Error::RdpError(RdpError::new(
                 RdpErrorKind::InvalidData,

--- a/src/nla/cssp.rs
+++ b/src/nla/cssp.rs
@@ -186,7 +186,7 @@ pub fn cssp_connect<S: Read + Write>(
         link.get_peer_certificate()?,
         "No public certificate available"
     )?
-    .to_der()?;
+    .0;
     let certificate = read_public_certificate(&certificate_der)?;
 
     // Now we can send back our challenge payload wit the public key encoded


### PR DESCRIPTION
Swaps native-tls library with rustls.
It indirectly removes the OpenSSL dependency.