### PR TITLE
Add `From<std::num::TryFromIntError>`

### DIFF
--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -198,6 +198,12 @@ impl<T: TryFromPrimitive> From<TryFromPrimitiveError<T>> for Error {
     }
 }
 
+impl From<std::num::TryFromIntError> for Error {
+    fn from(err: std::num::TryFromIntError) -> Self {
+        Error::TryError(err.to_string())
+    }
+}
+
 pub type RdpResult<T> = Result<T, Error>;
 
 /// Try options is waiting try trait for the next rust


### PR DESCRIPTION
Adds a `From` trait implementation that's helpful for the directory sharing implementation