### PR TITLE
Fix scroll wheel delta

### DIFF
--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -8,6 +8,7 @@ use num_enum::TryFromPrimitive;
 ///
 /// If bitmap is compress you can use the
 /// decompress function to handle it
+#[derive(Debug)]
 pub struct BitmapEvent {
     /// Pixel position from left of the left top angle
     pub dest_left: u16,
@@ -118,7 +119,7 @@ impl BitmapEvent {
 }
 
 #[repr(u8)]
-#[derive(Eq, PartialEq, TryFromPrimitive, Copy, Clone)]
+#[derive(Eq, PartialEq, TryFromPrimitive, Copy, Clone, Debug)]
 pub enum PointerButton {
     /// No button but a move
     None = 0,
@@ -131,7 +132,7 @@ pub enum PointerButton {
 }
 
 #[repr(u8)]
-#[derive(Eq, PartialEq, TryFromPrimitive, Copy, Clone)]
+#[derive(Eq, PartialEq, TryFromPrimitive, Copy, Clone, Debug)]
 pub enum PointerWheel {
     /// No wheel scroll.
     None = 0,
@@ -142,6 +143,7 @@ pub enum PointerWheel {
 }
 
 /// A mouse pointer event
+#[derive(Debug)]
 pub struct PointerEvent {
     /// horizontal position from top left angle of the window
     pub x: u16,
@@ -160,6 +162,7 @@ pub struct PointerEvent {
 /// Keyboard event
 /// It's a raw event using Scancode
 /// to inform which key is pressed
+#[derive(Debug)]
 pub struct KeyboardEvent {
     /// Scancode of the key
     pub code: u16,
@@ -168,6 +171,7 @@ pub struct KeyboardEvent {
 }
 
 /// All event handle by RDP protocol implemented by rdp-rs
+#[derive(Debug)]
 pub enum RdpEvent {
     /// Classic bitmap event
     Bitmap(BitmapEvent),


### PR DESCRIPTION
It turns out that negative scroll requires that we send the 9-bit two's complement of the delta (seen in FreeRDP [here](https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/client/common/client.c#L1071) and [here](https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/client/Wayland/wlf_input.c#L229)).

#### Notes to self
Relates to https://github.com/gravitational/teleport/issues/13690, which can be considered fixed once this is merged and the following `teleport` branches are updated with the new HEAD ref of this repo's `master` branch:
- `master`: TODO(link the PR)
- `branch/v10`: TODO(link the PR)
- `branch/v9`: TODO(link the PR)

Double check the [`Verify user input`](https://github.com/gravitational/teleport/blob/9c89af8d2d6d414e0e50693753cbed10b4a56fac/.github/ISSUE_TEMPLATE/testplan.md#L1004) section of the test plan on `branch/v10` and `branch/v9` after ref is updated.