### PR TITLE
Add optional FIPS feature and use BoringSSL with FIPS enabled for TLS connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ required-features = ["mstsc-rs"]
 # See: https://github.com/rust-lang/cargo/issues/4669
 integration = []
 mstsc-rs = ["hex", "winapi", "minifb", "clap", "libc"]
+fips = ["boring"]
 
 
 [dependencies]
@@ -44,6 +45,9 @@ ring = "0.16.20"
 rsa = "0.6.1"
 rustls = { version = "0.20.4", features = ["dangerous_configuration"]}
 x509-parser = "0.14.0"
+
+# fips
+boring = { version = "2.1.0", features = ["fips"], optional = true }
 
 # for mtsc-rs
 hex = { version = "^0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "fips")]
+extern crate boring;
 extern crate byteorder;
 #[cfg(feature = "mstsc-rs")]
 extern crate clap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ extern crate rand;
 extern crate rc4;
 extern crate ring;
 extern crate rsa;
+#[cfg(not(feature = "fips"))]
+extern crate rustls;
 #[cfg(feature = "mstsc-rs")]
 extern crate winapi;
 extern crate x509_parser;

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -1,6 +1,5 @@
 extern crate rustls;
 
-use self::rustls::Error as SslError;
 use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use std::fmt;
 use std::io::Error as IoError;
@@ -155,23 +154,19 @@ pub enum Error {
     /// SSL handshake error
     SslHandshakeError,
     /// SSL error
-    SslError(SslError),
+    SslError,
     /// ASN1 parser error
     ASN1Error(ASN1Error),
     /// try error
     TryError(String),
+    // All kind of parse error
+    FromError(String),
 }
 
 /// From IO Error
 impl From<IoError> for Error {
     fn from(e: IoError) -> Self {
         Error::Io(e)
-    }
-}
-
-impl From<SslError> for Error {
-    fn from(e: SslError) -> Error {
-        Error::SslError(e)
     }
 }
 

--- a/src/model/error.rs
+++ b/src/model/error.rs
@@ -1,5 +1,3 @@
-extern crate rustls;
-
 use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use std::fmt;
 use std::io::Error as IoError;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,4 +4,5 @@ pub mod link;
 #[macro_use]
 pub mod error;
 pub mod rnd;
+mod tls;
 pub mod unicode;

--- a/src/model/tls/default.rs
+++ b/src/model/tls/default.rs
@@ -1,0 +1,164 @@
+extern crate rustls;
+
+use self::rustls::{
+    client::{NoClientSessionStorage, ServerCertVerified, ServerCertVerifier},
+    Certificate as RustlsCertificate, ClientConfig, ClientConnection, Error as RustlsError,
+    RootCertStore, ServerName, Stream as RustlsStream,
+};
+use std::convert::TryInto;
+use std::fmt;
+use std::io::{self, Read, Write};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use model::error::{Error, RdpError, RdpErrorKind, RdpResult};
+
+/// Marks all server certificates as valid
+/// so it can be used to turn off the server certificate
+/// validation on the client-side.
+struct DummyTlsVerifier;
+
+impl ServerCertVerifier for DummyTlsVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &RustlsCertificate,
+        _intermediates: &[RustlsCertificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> std::result::Result<ServerCertVerified, RustlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
+
+#[derive(Clone)]
+pub struct Certificate(RustlsCertificate);
+
+impl Certificate {
+    pub fn from_der(der: &[u8]) -> RdpResult<Self> {
+        Ok(Self(RustlsCertificate(der.to_vec())))
+    }
+
+    pub fn to_der(&self) -> RdpResult<Vec<u8>> {
+        Ok(self.0 .0.clone())
+    }
+}
+
+/// Copied from rustls library with removed trait bounds (Read + Write)
+/// By removing trait bounds we don't have to update
+/// other structs that depends on the Stream enum
+pub struct TlsStream<T: Sized> {
+    /// Our conneciton
+    pub conn: ClientConnection,
+
+    /// The underlying transport, like a socket
+    pub sock: T,
+}
+
+impl<T> TlsStream<T>
+where
+    T: Read + Write,
+{
+    /// Get a reference to the underlying socket
+    pub fn get_ref(&self) -> &T {
+        &self.sock
+    }
+
+    /// Get a mutable reference to the underlying socket
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.sock
+    }
+
+    fn as_stream(&mut self) -> RustlsStream<ClientConnection, T> {
+        RustlsStream {
+            conn: &mut self.conn,
+            sock: &mut self.sock,
+        }
+    }
+}
+
+impl<T> Read for TlsStream<T>
+where
+    T: Read + Write,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.as_stream().read(buf)
+    }
+}
+
+impl<T> Write for TlsStream<T>
+where
+    T: Read + Write,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.as_stream().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.as_stream().flush()
+    }
+}
+
+impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self, fmt)
+    }
+}
+
+impl<T> TlsStream<T>
+where
+    T: Read + Write,
+{
+    pub fn new(check_certificate: bool, sock: T) -> RdpResult<Self> {
+        let root_store = RootCertStore::empty();
+        let mut config = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
+
+        if !check_certificate {
+            let mut config = config.dangerous();
+            let verifier = Arc::new(DummyTlsVerifier {});
+            config.set_certificate_verifier(verifier)
+        }
+
+        config.enable_sni = false;
+        // We do not use the Server Name Indication (SNI) extension
+        // during the client handshake, but the rustls library requires
+        // a valid DNS domain name for the server regardless of that
+        // setting, so we need to provide a valid name.
+        // We can't use an empty string here.
+        let server_name: ServerName = "servername".try_into().unwrap();
+        config.session_storage = Arc::new(NoClientSessionStorage {});
+
+        let arc = Arc::new(config);
+        let conn = ClientConnection::new(arc, server_name).map_err(|_| Error::SslError)?;
+
+        Ok(Self { conn, sock })
+    }
+
+    pub fn peer_certificate(&self) -> RdpResult<Option<Certificate>> {
+        if let Some(certs) = self.conn.peer_certificates() {
+            if let Some(cert) = certs.first() {
+                Ok(Some(Certificate(cert.clone())))
+            } else {
+                Err(Error::RdpError(RdpError::new(
+                    RdpErrorKind::InvalidData,
+                    "certificates chain is empty",
+                )))
+            }
+        } else {
+            Err(Error::RdpError(RdpError::new(
+                RdpErrorKind::InvalidData,
+                "certificates chain is unavialable",
+            )))
+        }
+    }
+
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        self.conn.send_close_notify();
+        self.flush()?;
+        Ok(())
+    }
+}

--- a/src/model/tls/fips.rs
+++ b/src/model/tls/fips.rs
@@ -1,8 +1,6 @@
-extern crate boring;
-
-use self::boring::ssl::{self, SslConnector, SslMethod, SslStream, SslVerifyMode};
-use self::boring::x509::X509;
-use self::boring::fips;
+use boring::ssl::{self, SslConnector, SslMethod, SslStream, SslVerifyMode};
+use boring::x509::X509;
+use boring::fips;
 use model::error::{Error, RdpResult};
 use std::fmt;
 use std::io::{self, Read, Write};

--- a/src/model/tls/fips.rs
+++ b/src/model/tls/fips.rs
@@ -1,0 +1,99 @@
+extern crate boring;
+
+use self::boring::ssl::{self, SslConnector, SslMethod, SslStream, SslVerifyMode};
+use self::boring::x509::X509;
+use self::boring::fips;
+use model::error::{Error, RdpResult};
+use std::fmt;
+use std::io::{self, Read, Write};
+
+#[derive(Clone)]
+pub struct Certificate(X509);
+
+impl Certificate {
+    pub fn from_der(der: &[u8]) -> RdpResult<Self> {
+        Ok(Certificate(
+            X509::from_der(der).map_err(|e| Error::FromError(e.to_string()))?,
+        ))
+    }
+
+    pub fn to_der(&self) -> RdpResult<Vec<u8>> {
+        Ok(self
+            .0
+            .to_der()
+            .map_err(|e| Error::FromError(e.to_string()))?)
+    }
+}
+
+pub struct TlsStream<S>(SslStream<S>);
+
+impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl<S: Read + Write> TlsStream<S> {
+    pub fn new(check_certificate: bool, stream: S) -> RdpResult<Self> {
+        if !fips::enabled() {
+            panic!("FIPS mode not enabled")
+        }
+
+        let mut connector = SslConnector::builder(SslMethod::tls())
+            .map_err(|_| Error::SslError)?
+            .build()
+            .configure()
+            .map_err(|_| Error::SslError)?
+            .verify_hostname(false)
+            .use_server_name_indication(false);
+
+        if !check_certificate {
+            connector.set_verify(SslVerifyMode::NONE);
+        }
+
+        let stream = match connector.connect("", stream) {
+            Ok(stream) => stream,
+            Err(_) => return Err(Error::SslError),
+        };
+
+        Ok(Self(stream))
+    }
+
+    pub fn get_ref(&self) -> &S {
+        self.0.get_ref()
+    }
+
+    pub fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut()
+    }
+
+    pub fn peer_certificate(&self) -> RdpResult<Option<Certificate>> {
+        Ok(self.0.ssl().peer_certificate().map(Certificate))
+    }
+
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        match self.0.shutdown() {
+            Ok(_) => Ok(()),
+            Err(ref e) if e.code() == ssl::ErrorCode::ZERO_RETURN => Ok(()),
+            Err(e) => Err(e
+                .into_io_error()
+                .unwrap_or_else(|e| io::Error::new(io::ErrorKind::Other, e))),
+        }
+    }
+}
+
+impl<S: Read + Write> Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<S: Read + Write> Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}

--- a/src/model/tls/mod.rs
+++ b/src/model/tls/mod.rs
@@ -1,0 +1,78 @@
+#[cfg(not(feature = "fips"))]
+#[path = "default.rs"]
+mod imp;
+#[cfg(feature = "fips")]
+#[path = "fips.rs"]
+mod imp;
+
+use model::error::RdpResult;
+use std::fmt;
+use std::io::{self, Read, Write};
+
+#[derive(Clone)]
+pub struct Certificate(imp::Certificate);
+
+impl Certificate {
+    // Parses a DER-formatted X509 certificate.
+    pub fn from_der(der: &[u8]) -> RdpResult<Certificate> {
+        let cert = imp::Certificate::from_der(der)?;
+        Ok(Certificate(cert))
+    }
+
+    /// Returns the DER-encoded representation of this certificate.
+    pub fn to_der(&self) -> RdpResult<Vec<u8>> {
+        let der = self.0.to_der()?;
+        Ok(der)
+    }
+}
+
+pub struct TlsStream<S>(imp::TlsStream<S>);
+
+impl<S: fmt::Debug> fmt::Debug for TlsStream<S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, fmt)
+    }
+}
+
+impl<S: Read + Write> TlsStream<S> {
+    pub fn new(check_certificate: bool, sock: S) -> RdpResult<Self> {
+        Ok(Self(imp::TlsStream::new(check_certificate, sock)?))
+    }
+
+    /// Returns a shared reference to the inner stream.
+    pub fn get_ref(&self) -> &S {
+        self.0.get_ref()
+    }
+
+    /// Returns a mutable reference to the inner stream.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut()
+    }
+
+    /// Returns the peer's leaf certificate, if available.
+    pub fn peer_certificate(&self) -> RdpResult<Option<Certificate>> {
+        Ok(self.0.peer_certificate()?.map(Certificate))
+    }
+
+    /// Shuts down the TLS session.
+    pub fn shutdown(&mut self) -> io::Result<()> {
+        self.0.shutdown()?;
+        Ok(())
+    }
+}
+
+impl<S: Read + Write> Read for TlsStream<S> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+}
+
+impl<S: Read + Write> Write for TlsStream<S> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}

--- a/src/model/tls/mod.rs
+++ b/src/model/tls/mod.rs
@@ -1,8 +1,5 @@
-#[cfg(not(feature = "fips"))]
-#[path = "default.rs"]
-mod imp;
-#[cfg(feature = "fips")]
-#[path = "fips.rs"]
+#[cfg_attr(feature = "fips", path = "fips.rs")]
+#[cfg_attr(not(feature = "fips"), path = "default.rs")]
 mod imp;
 
 use model::error::RdpResult;

--- a/src/nla/cssp.rs
+++ b/src/nla/cssp.rs
@@ -186,7 +186,8 @@ pub fn cssp_connect<S: Read + Write>(
         link.get_peer_certificate()?,
         "No public certificate available"
     )?
-    .0;
+    .to_der()?;
+
     let certificate = read_public_certificate(&certificate_der)?;
 
     // Now we can send back our challenge payload wit the public key encoded


### PR DESCRIPTION
It's the first step to make Teleport's Desktop Access FIPS compatibile: https://github.com/gravitational/teleport/issues/9987