### PR TITLE
Fix `performanceFlags` and make 16bpp explicit

### DIFF
--- a/src/core/gcc.rs
+++ b/src/core/gcc.rs
@@ -14,18 +14,44 @@ const H221_SC_KEY: [u8; 4] = *b"McDn";
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/00f1da4a-ee9c-421a-852f-c19f92343d73?redirectedfrom=MSDN
 #[repr(u32)]
 #[allow(dead_code)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Version {
-    RdpVersion = 0x00080001,
-    RdpVersion5plus = 0x00080004,
+    // RDP 4.0 clients
+    RdpVersion4 = 0x00080001,
+    // RDP 5.0, 5.1, 5.2, 6.0, 6.1, 7.0, 7.1, 8.0, and 8.1 clients
+    RdpVersion5to8 = 0x00080004,
+    RdpVersion10_0 = 0x00080005,
+    RdpVersion10_1 = 0x00080006,
+    RdpVersion10_2 = 0x00080007,
+    RdpVersion10_3 = 0x00080008,
+    RdpVersion10_4 = 0x00080009,
+    RdpVersion10_5 = 0x0008000A,
+    RdpVersion10_6 = 0x0008000B,
+    RdpVersion10_7 = 0x0008000C,
+    RdpVersion10_8 = 0x0008000D,
+    RdpVersion10_9 = 0x0008000E,
+    RdpVersion10_10 = 0x0008000F,
+    RdpVersion10_11 = 0x00080010,
     Unknown,
 }
 
 impl From<u32> for Version {
     fn from(e: u32) -> Self {
         match e {
-            0x00080001 => Version::RdpVersion5plus,
-            0x00080004 => Version::RdpVersion,
+            0x00080001 => Version::RdpVersion4,
+            0x00080004 => Version::RdpVersion5to8,
+            0x00080005 => Version::RdpVersion10_0,
+            0x00080006 => Version::RdpVersion10_1,
+            0x00080007 => Version::RdpVersion10_2,
+            0x00080008 => Version::RdpVersion10_3,
+            0x00080009 => Version::RdpVersion10_4,
+            0x0008000A => Version::RdpVersion10_5,
+            0x0008000B => Version::RdpVersion10_6,
+            0x0008000C => Version::RdpVersion10_7,
+            0x0008000D => Version::RdpVersion10_8,
+            0x0008000E => Version::RdpVersion10_9,
+            0x0008000F => Version::RdpVersion10_10,
+            0x00080010 => Version::RdpVersion10_11,
             _ => Version::Unknown,
         }
     }
@@ -90,7 +116,7 @@ pub enum KeyboardType {
 
 #[repr(u16)]
 #[allow(dead_code)]
-enum HighColor {
+pub enum HighColor {
     HighColor4BPP = 0x0004,
     HighColor8BPP = 0x0008,
     HighColor15BPP = 0x000f,
@@ -218,7 +244,7 @@ pub fn client_core_data(parameter: Option<ClientData>) -> Component {
         height: 0,
         layout: KeyboardLayout::French,
         server_selected_protocol: 0,
-        rdp_version: Version::RdpVersion5plus,
+        rdp_version: Version::RdpVersion5to8,
         name: "".to_string(),
         connection_type: None,
     });
@@ -253,9 +279,9 @@ pub fn client_core_data(parameter: Option<ClientData>) -> Component {
         "serialNumber" => U32::LE(0),
         "highColorDepth" => U16::LE(HighColor::HighColor24BPP as u16),
         "supportedColorDepths" => U16::LE(
-            //Support::RnsUd15BPPSupport as u16 |
+            Support::RnsUd15BPPSupport as u16 |
             Support::RnsUd16BPPSupport as u16 |
-            //Support::RnsUd24BPPSupport as u16 |
+            Support::RnsUd24BPPSupport as u16 |
             Support::RnsUd32BPPSupport as u16
             ),
         "earlyCapabilityFlags" => U16::LE(capability_flags),

--- a/src/core/gcc.rs
+++ b/src/core/gcc.rs
@@ -277,11 +277,11 @@ pub fn client_core_data(parameter: Option<ClientData>) -> Component {
         "postBeta2ColorDepth" => U16::LE(ColorDepth::RnsUdColor8BPP as u16),
         "clientProductId" => U16::LE(1),
         "serialNumber" => U32::LE(0),
-        "highColorDepth" => U16::LE(HighColor::HighColor24BPP as u16),
+        "highColorDepth" => U16::LE(HighColor::HighColor16BPP as u16),
         "supportedColorDepths" => U16::LE(
-            Support::RnsUd15BPPSupport as u16 |
+            // Support::RnsUd15BPPSupport as u16 |
             Support::RnsUd16BPPSupport as u16 |
-            Support::RnsUd24BPPSupport as u16 |
+            // Support::RnsUd24BPPSupport as u16 |
             Support::RnsUd32BPPSupport as u16
             ),
         "earlyCapabilityFlags" => U16::LE(capability_flags),

--- a/src/core/global.rs
+++ b/src/core/global.rs
@@ -1016,7 +1016,7 @@ impl Client {
                         | capability::GeneralExtraFlag::FastpathOutputSupported as u16
                 )))),
                 capability_set(Some(capability::ts_bitmap_capability_set(
-                    Some(HighColor::HighColor24BPP as u16),
+                    Some(HighColor::HighColor16BPP as u16),
                     Some(self.width),
                     Some(self.height)
                 ))),

--- a/src/core/global.rs
+++ b/src/core/global.rs
@@ -14,6 +14,8 @@ use num_enum::TryFromPrimitive;
 use std::convert::TryFrom;
 use std::io::{Cursor, Read, Write};
 
+use super::gcc::HighColor;
+
 /// Raw PDU type use by the protocol
 #[repr(u16)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug, TryFromPrimitive)]
@@ -1014,7 +1016,7 @@ impl Client {
                         | capability::GeneralExtraFlag::FastpathOutputSupported as u16
                 )))),
                 capability_set(Some(capability::ts_bitmap_capability_set(
-                    Some(0x0018),
+                    Some(HighColor::HighColor24BPP as u16),
                     Some(self.width),
                     Some(self.height)
                 ))),

--- a/src/core/mcs.rs
+++ b/src/core/mcs.rs
@@ -233,7 +233,7 @@ impl<S: Read + Write> Client<S> {
             height: screen_height,
             layout: keyboard_layout,
             server_selected_protocol: self.x224.get_selected_protocols() as u32,
-            rdp_version: Version::RdpVersion5plus,
+            rdp_version: Version::RdpVersion5to8,
             name: client_name,
             connection_type: None,
         }));
@@ -452,7 +452,10 @@ impl<S: Read + Write> Client<S> {
     /// This function check if the client
     /// version protocol choose is 5+
     pub fn is_rdp_version_5_plus(&self) -> bool {
-        self.server_data.as_ref().unwrap().rdp_version == Version::RdpVersion5plus
+        match self.server_data.as_ref().unwrap().rdp_version {
+            Version::RdpVersion4 | Version::Unknown => false,
+            _ => true,
+        }
     }
 
     /// Getter of the user id negotiated during connection steps

--- a/src/core/sec.rs
+++ b/src/core/sec.rs
@@ -72,12 +72,14 @@ enum AfInet {
 
 /// On RDP version > 5
 /// Client have to send IP information
+///
+/// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/05ada9e4-a468-494b-8694-eb806a0ecc89
 fn rdp_extended_infos(performance_flags: u32) -> Component {
     component![
         "clientAddressFamily" => U16::LE(AfInet::AfInet as u16),
-        "cbClientAddress" => U16::LE(2),
+        "cbClientAddress" => U16::LE(2), // size in bytes of the hardcoded null terminator in clientAddress
         "clientAddress" => b"\x00\x00".to_vec(),
-        "cbClientDir" => U16::LE(2),
+        "cbClientDir" => U16::LE(2), // size in bytes of the hardcoded null terminator in clientDir
         "clientDir" => b"\x00\x00".to_vec(),
         "clientTimeZone" => vec![0; 172],
         "clientSessionId" => U32::LE(0),

--- a/src/core/sec.rs
+++ b/src/core/sec.rs
@@ -1,6 +1,6 @@
 use core::license;
 use core::mcs;
-use model::data::{Component, DynOption, MessageOption, Trame, U16, U32};
+use model::data::{Component, Trame, U16, U32};
 use model::error::RdpResult;
 use model::unicode::Unicode;
 use std::io::{Read, Write};
@@ -74,9 +74,9 @@ enum AfInet {
 fn rdp_extended_infos(performance_flags: u32) -> Component {
     component![
         "clientAddressFamily" => U16::LE(AfInet::AfInet as u16),
-        "cbClientAddress" => DynOption::new(U16::LE(0), |x| MessageOption::Size("clientAddress".to_string(), x.inner() as usize + 2)),
+        "cbClientAddress" => U16::LE(2),
         "clientAddress" => b"\x00\x00".to_vec(),
-        "cbClientDir" => U16::LE(0),
+        "cbClientDir" => U16::LE(2),
         "clientDir" => b"\x00\x00".to_vec(),
         "clientTimeZone" => vec![0; 172],
         "clientSessionId" => U32::LE(0),

--- a/src/core/sec.rs
+++ b/src/core/sec.rs
@@ -58,6 +58,7 @@ pub enum ExtendedInfoFlag {
     PerfDisableFullWindowDrag = 0x00000002,
     PerfDisableMenuAnimations = 0x00000004,
     PerfDisableTheming = 0x00000008,
+    PerfDisableCursorShadow = 0x00000020,
     PerfDisableCursorBlink = 0x00000040,
     PerfEnableFontSmoothing = 0x00000080,
     PerfEnableDesktopComposition = 0x00000100,


### PR DESCRIPTION
- Adds more specificity for detecting the RDP version in `pub enum Version`
- Fixes a bug in `impl From<u32> for Version`
- Fixes a bug in `rdp_extended_infos` which was preventing us from being able to send performance flags
- Request 16bpp explicitly rather than requesting 24bpp but also saying we only support 16bpp or 32bpp
