### PR TITLE
Clean up 32bpp RLE decoder

### DIFF
--- a/src/core/capability.rs
+++ b/src/core/capability.rs
@@ -247,7 +247,7 @@ pub fn ts_bitmap_capability_set(
              // Note: this library's bulk decompressor does not support all
              // of possible features, so advertising support for them here
              // will require additional updates.
-            "drawingFlags" => 0 ,
+            "drawingFlags" => 0
         ],
     }
 }


### PR DESCRIPTION
The existing code for this was a direct port of C code. As a result, it had a bunch of variables with scope larger than necessary and no documentation.

No functional changes here, just simplify the code and add comments and links to the relevant parts of the spec to make things easier to understand.

Included a new test to verify that behavior is the same before and after the change.