### PR TITLE
Fix cargo test

### DIFF
--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -74,7 +74,7 @@ impl<S: Read + Write> RdpClient<S> {
     /// ```no_run
     /// use std::net::{SocketAddr, TcpStream};
     /// use rdp::core::client::Connector;
-    /// use rdp::core::event::{RdpEvent, PointerEvent, PointerButton};
+    /// use rdp::core::event::{RdpEvent, PointerEvent, PointerButton, PointerWheel};
     /// let addr = "127.0.0.1:3389".parse::<SocketAddr>().unwrap();
     /// let tcp = TcpStream::connect(&addr).unwrap();
     /// let mut connector = Connector::new()
@@ -87,6 +87,8 @@ impl<S: Read + Write> RdpClient<S> {
     ///         x: 100 as u16,
     ///         y: 100 as u16,
     ///         button: PointerButton::Left,
+    ///         wheel: PointerWheel::None,
+    ///         wheel_delta: 0,
     ///         down: true
     ///     }
     /// )).unwrap()

--- a/src/core/tpkt.rs
+++ b/src/core/tpkt.rs
@@ -58,7 +58,7 @@ impl<S: Read + Write> Client<S> {
     ///
     /// # Example
     /// ```
-    /// #[macro_use]
+    /// # #[macro_use]
     /// # extern crate rdp;
     /// # use rdp::core::tpkt;
     /// # use rdp::model::link;
@@ -69,13 +69,14 @@ impl<S: Read + Write> Client<S> {
     ///     tpkt.write(trame![U16::BE(4), U32::LE(3)]).unwrap();
     ///     // get_link and get_stream are not available on Crate
     ///     // only use for integration test [features = integration]
+    ///     # #[cfg(feature = "integration")]
     ///     if let link::Stream::Raw(e) = tpkt.get_link().get_stream() {
     ///         assert_eq!(e.into_inner(), [3, 0, 0, 10, 0, 4, 3, 0, 0, 0])
     ///     }
     ///     else {
     ///         panic!("Must not happen")
     ///     }
-    /// }
+    /// # }
     /// ```
     pub fn write<T: 'static>(&mut self, message: T) -> RdpResult<()>
     where

--- a/src/model/link.rs
+++ b/src/model/link.rs
@@ -122,6 +122,7 @@ impl<S: Read + Write> Link<S> {
     ///         "foo" => U32::LE(1)
     ///     ]).unwrap();
     ///
+    ///     # #[cfg(feature = "integration")]
     ///     if let Stream::Raw(r) = link.get_stream() {
     ///         assert_eq!(r.into_inner(), [1, 0, 0, 0])
     ///     }


### PR DESCRIPTION
Some of the documentation tests were using methods behind the integration feature, which was not enabled, prevenging the examples from compiling.