### PR TITLE
Upgrade `boring` from v3.1.0 to v4.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rustls = { version = "0.20.4", features = ["dangerous_configuration"]}
 x509-parser = "0.14.0"
 
 # fips
-boring = { version = "3.1.0", features = ["fips"], optional = true }
+boring = { version = "4.3.0", features = ["fips"], optional = true }
 
 # for mtsc-rs
 hex = { version = "^0.4", optional = true }


### PR DESCRIPTION
Needed for clang / cmake build fixes.